### PR TITLE
Update root readme to make learning by example easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,25 @@
 # Hotkys
 
-Web site and RayCast extension that allows you to find shortcuts for your app.
+Website and Raycast extension that allows you to find shortcuts for your app.
 
-RayCast extension adds additional automation features:
+The Raycast extension adds additional automation features:
 
 1. Find shortcuts for the frontmost application
 2. Run shortcuts by selecting from the list
 3. Copy bundle id for the frontmost application
 
-## Shortcuts Contribution
+## Contributing shortcuts
 
-Shortcuts are stored as a json files in `shortcuts-disco-site/shortcuts-data`.
-GitHub [link](https://github.com/solomkinmv/shortcuts-disco/tree/main/shortcuts-disco-site/shortcuts-data).
+Shortcut definitions are stored as JSON files in [`shortcuts-disco-site/shortcuts-data`](shortcuts-disco-site/shortcuts-data). Each application has one file.
 
-Interfaces for input model can be found by
-this [link](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/src/lib/model/input/input-models.ts).
-
-To add new application create a json file in `shortcuts-disco-site/shortcuts-data` with following template:
-
-```json
-{
-  "$schema": "schema/shortcut.schema.json"
-}
-```
-
-Schema will help with json structure. It doesn't provide all the validation, but dramatically simplifies the whole
-process.
-
-Each application is described by `name`, `slug` and optional `bundleId` of the macOS application.
-
-* App contains `keymaps`
-* Keymap contain `title` and list of `sections` 
-* Section contains `title` and list of `shortcuts`
-* Shortcut contain `title`, `comment` and shortcut declaration inside `key` property. There should be at least `key` or `comment` field. Key contains structured shortcut declaration while comment is just a string value.
-
-Shortcuts `key` rules:
-* Key consist of modifiers plus base key separated by `+` sign.
-* Supported modifiers: `ctrl`, `shift`, `opt`, `cmd`. Modifiers should be specified in that exact order, lowercase [{@link modifierTokens}](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/src/lib/model/internal/modifiers.ts).
-* Final shortcut token should always be a base key. List of all base keys: [{@link public/data/key-codes.json}](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/public/data/key-codes.json).
-* Examples: `ctrl+s`, `shift+cmd+e`.
-* Shortcut macro or sequences of shortcuts are also supported and should be separated by space (` `).
-* Example: `cmd+k cmd+s` (first press `Cmd+K` and then `Cmd+S`)
-
-<details>
-  <summary>Basic example of shortcuts for Safari</summary>
+To add shortcuts for a new application or web app, create a new JSON file, like `example-app.json`. To understand the required structure, take a look at this basic example with a subset of Safari's shortcuts:
 
 ```json
 {
   "$schema": "schema/shortcut.schema.json",
   "bundleId": "com.apple.Safari",
   "name": "Safari",
+  "slug": "safari",
   "keymaps": [
     {
       "title": "Default",
@@ -64,11 +34,11 @@ Shortcuts `key` rules:
           ]
         },
         {
-          "title": "Current Webpage",
-          "shortcuts": [
+          "title": "Other",
+           "shortcuts": [
             {
-              "title": "Search the current webpage",
-              "key": "cmd+f"
+              "title": "Modify the toolbar",
+              "comment": "Hold Cmd while dragging a toolbar element"
             },
             {
               "title": "Print the current webpage",
@@ -81,11 +51,38 @@ Shortcuts `key` rules:
   ]
 }
 ```
-</details>
+The structure contains the following information:
 
-### Additional information
+**Application information**
+- Each application has a `name` and `slug`.
+- The `bundleId` is an optional field, which helps identify a macOS application. It is not applicable to websites or web apps. Use the Raycast command "Copy Current App's Bundle Id" included with the Raycast extension to find the bundle Id of the application you want to add. 
+- An application can have multiple `keymaps`. Usually there is just one, named "Default". A keymap can have multiple sections of shortcuts. Each one has a title.
 
-Use `prettify` script to format json files and fix order of key modifiers.
+**Shortcut information**
+- A shortcut definition always has a `title`. For the rest, it must contain a `key` field, `comment` field, or both. 
+- `key` contains a **structured** shortcut declaration in a string. The rules are as follows:
+  * A `key` consists of modifiers plus a base key separated by `+` sign(s).
+  * Supported modifiers: `ctrl`, `shift`, `opt`, `cmd`. Modifiers should be specified in that exact order and be lowercase [{@link modifierTokens}](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/src/lib/model/internal/modifiers.ts).
+    - ❌ Invalid example: ~~`Cmd+Shift+Option+E`~~
+    - ✅ Valid example: `shift+opt+cmd+e`
+  * Final shortcut token should always be a base key. List of all base keys: [{@link public/data/key-codes.json}](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/public/data/key-codes.json).
+    * Examples: `ctrl+s`, `shift+cmd+e`.
+  * Shortcut macro or sequences of shortcuts are also supported and should be separated by space (` `).
+    * Example: `cmd+k cmd+s` (first press `Cmd+K` and then `Cmd+S`)
+- `comment` can be any string. Use it to explain the shortcut further, if necessary, or to represent shortcuts that are more easily described in a sentence (such as "Hold key Cmd while clicking item X") 
+
+The TypeScript interfaces for the keyboard definition model with all options can be found [here](https://github.com/solomkinmv/shortcuts-disco/blob/main/shortcuts-disco-site/src/lib/model/input/input-models.ts).
+
+
+### JSON schema
+
+The schema in the first line (`"$schema": "schema/shortcut.schema.json"`) will help with validating the JSON structure.
+
+Using it, an editor like VS Code will automatically show warnings if the JSON structure is invalid. It doesn't provide all the required validation, but dramatically simplifies the whole process.
+
+### Fixing the JSON format
+
+Use the `prettify` script to format all the JSON files and fix the order of key modifiers.
 
 Go to `shortcuts-disco-site` folder and run:
 


### PR DESCRIPTION
Hey! Here's a proposal for a slightly updated README file.

It includes the following changes:
- Most importantly: replace the "template" example with the Safari example. Un-hide the Safari example. This is for people with a short attention span that don't read and just want to copy-paste stuff, learn by example, and get started immediately. I think that's most people 🙂 
  - Simplify the Safari example by removing the "Current webpage" section
  - Include a shortcut that only has a "comment" (to enable learning by example)
- Small grammar fixes (for example; web site -> website; RayCast -> Raycast)
- Relative link for the shortcuts data, so it also works in an editor like VSCode, and in any deployed GitHub location.
- Reworked the rest of the information to be a bit more condensed below the example.
  - Gave an example of an invalid and valid key modifier combination (because that part wasn't so intuitive for me!) 

To see it in action; check here https://github.com/th0rgall/hotkys/tree/readme-update